### PR TITLE
Only write if content stream has content.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,9 @@ module.exports = {
     var stream = fs.createWriteStream(filepath);
     stream.once('open', function(fd) {
       contents.forEach(function (content) {
-        stream.write(content);
+        if ( content ) {
+          stream.write(content);
+        }
       });
       stream.end();
     });


### PR DESCRIPTION
Doxygen will happily output empty nodes, which createWriteStream chokes on. This fixed it for me.