### PR TITLE
Fixing issue with missing namespace reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,11 +94,19 @@ module.exports = {
           return comp.members.find(member => member.name == "make_binary_tree")
         })
 
+        // Fixing absolute location
+        compounds.forEach(comp => {
+          comp.members.forEach(member => {
+            if (member.location)
+              member.location = member.location.substring(26)
+          })
+        })
+
         compounds.forEach(comp => {
           comp.members.forEach(member => {
             console.log("filtered member", member)
             var contents = templates.render(member);
-            helpers.writeFile(util.format(options.output, member.name), [contents]);
+            helpers.writeFile(util.format(options.output, member.refid), [contents]);
           })
         })
 

--- a/index.js
+++ b/index.js
@@ -95,11 +95,15 @@ module.exports = {
         })
 
         compounds.forEach(comp => {
-          console.log("filtered compound", comp)
+          comp.members.forEach(member => {
+            console.log("filtered member", member)
+            var contents = templates.render(member);
+            helpers.writeFile(util.format(options.output, member.name), [contents]);
+          })
         })
 
-        var contents = templates.renderArray(compounds);
-        helpers.writeFile(options.output, contents);
+        //var contents = templates.renderArray(compounds);
+        //helpers.writeFile(options.output, contents);
       }
     });
   }

--- a/index.js
+++ b/index.js
@@ -84,8 +84,20 @@ module.exports = {
       // Output single file
       else {
         root.filterChildren(options.filters);
+        console.log("root stapl members");
+        root.compounds.stapl.members.forEach(mem => {
+          console.log("member", mem);
+        })
 
-        var compounds = root.toFilteredArray('compounds');
+        var compounds = root.toArray('compounds');
+        compounds = compounds.filter(comp => {
+          return comp.members.find(member => member.name == "make_binary_tree")
+        })
+
+        compounds.forEach(comp => {
+          console.log("filtered compound", comp)
+        })
+
         var contents = templates.renderArray(compounds);
         helpers.writeFile(options.output, contents);
       }

--- a/src/compound.js
+++ b/src/compound.js
@@ -35,6 +35,8 @@ Compound.prototype = {
       return this[key];
     }.bind(this[type]));
 
+    console.log("toArray found compounds ", arr)
+
     if (type == 'compounds') {
       var all = new Array();
       arr.forEach(function (compound) {
@@ -79,19 +81,19 @@ Compound.prototype = {
       if (item) {
 
         // skip empty namespaces
-        if (item.kind == 'namespace') {
+        /*if (item.kind == 'namespace') {
           if ((!item.filtered.compounds || !item.filtered.compounds.length) &&
             (!item.filtered.members || !item.filtered.members.length)) {
             // log.verbose('Skip empty namespace', item.name);
             return;
           }
-        }
+        }*/
 
         // skip items not belonging to current group
-        else if (groupid && item.groupid != groupid) {
+        /*else if (groupid && item.groupid != groupid) {
           // log.verbose('Skip item from foreign group', item.kind, item.name, item.groupid, group.id);
           return;
-        }
+        }*/
 
         (categories[item[key]] || (categories[item[key]] = [])).push(item);
       }

--- a/src/compound.js
+++ b/src/compound.js
@@ -35,7 +35,7 @@ Compound.prototype = {
       return this[key];
     }.bind(this[type]));
 
-    console.log("toArray found compounds ", arr)
+    //console.log("toArray found compounds ", arr)
 
     if (type == 'compounds') {
       var all = new Array();

--- a/src/parser.js
+++ b/src/parser.js
@@ -321,11 +321,14 @@ module.exports = {
           compounddef.innerclass.forEach(function (innerclassdef) {
               if (compound.kind == 'namespace') {
                 // log.verbose('Assign ' + innerclassdef.$.refid + ' to namespace ' + compound.name);
-                this.assignToNamespace(compound, this.references[innerclassdef.$.refid]);
+
+                if (this.references[innerclassdef.$.refid])
+                  this.assignToNamespace(compound, this.references[innerclassdef.$.refid]);
               }
               else if (compound.kind == 'group') {
                 // log.verbose('Assign ' + innerclassdef.$.refid + ' to group ' + compound.name);
-                this.assignClassToGroup(compound, this.references[innerclassdef.$.refid]);
+                if (this.references[innerclassdef.$.refid])
+                  this.assignClassToGroup(compound, this.references[innerclassdef.$.refid]);
               }
           }.bind(this));
         }

--- a/src/parser.js
+++ b/src/parser.js
@@ -274,6 +274,7 @@ module.exports = {
 
     if (compounddef.sectiondef) {
       compounddef.sectiondef.forEach(function (section) {
+        console.log("WTF: found section", section);
         switch (section.$['kind']) {
           case 'friend':
           case 'public-attrib':
@@ -282,6 +283,7 @@ module.exports = {
           case 'protected-func':
           case 'private-attrib':
           case 'private-func':
+          case 'func':
             if (section.memberdef) {
               section.memberdef.forEach(function (memberdef) {
                 var member = this.references[memberdef.$.id];
@@ -345,7 +347,7 @@ module.exports = {
         }
         break;
       default:
-        console.assert(true);
+        console.log("WARN -- Not supported kind:", compound.kind);
     }
 
     return;

--- a/src/parser.js
+++ b/src/parser.js
@@ -36,7 +36,7 @@ function toMarkdown(element, context) {
           case 'ref': return s + markdown.link(toMarkdown(element.$$), '#' + element.$.refid, true);
           case '__text__': s = element._; break;
           case 'emphasis': s = '*'; break;
-          case 'bold': s = '**'; break;
+          case 'bold': s = '#### '; break;
           case 'parametername': s = '*'; break;
           case 'computeroutput': s = '`'; break;
           case 'parameterlist': s = '\n#### Parameters\n'; break;
@@ -92,7 +92,7 @@ function toMarkdown(element, context) {
           case 'parameterlist':
           case 'para': s += '\n\n'; break;
           case 'emphasis': s += '*'; break;
-          case 'bold': s += '**'; break;
+          case 'bold': s += ''; break;
           case 'parameteritem': s += '\n'; break;
           case "computeroutput": s += '`'; break;
           case 'parametername': s += '*: '; break;
@@ -212,6 +212,8 @@ module.exports = {
     }
 
     member.proto = '```c++\n' + m.join("") + '\n```'
+    member.location = memberdef.location[0].$.file
+    console.log("memberdef location", memberdef.location)
   },
 
   assignToNamespace: function (compound, child) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -37,7 +37,7 @@ function toMarkdown(element, context) {
           case '__text__': s = element._; break;
           case 'emphasis': s = '*'; break;
           case 'bold': s = '**'; break;
-          case 'parametername':
+          case 'parametername': s = '*'; break;
           case 'computeroutput': s = '`'; break;
           case 'parameterlist': s = '\n#### Parameters\n'; break;
           case 'parameteritem': s = '* '; break;
@@ -95,7 +95,7 @@ function toMarkdown(element, context) {
           case 'bold': s += '**'; break;
           case 'parameteritem': s += '\n'; break;
           case "computeroutput": s += '`'; break;
-          case 'parametername': s += '` '; break;
+          case 'parametername': s += '*: '; break;
           case 'entry': s = markdown.escape.cell(s) + '|'; break;
           case 'programlisting': s += '```\n'; break;
           case 'codeline': s += '\n'; break;
@@ -168,7 +168,6 @@ module.exports = {
 
     switch (member.kind) {
       case 'function':
-        m = m.concat(memberdef.$.prot, ' '); // public, private, ...
         if (memberdef.templateparamlist) {
           m.push('template<');
           memberdef.templateparamlist[0].param.forEach(function (param, argn) {
@@ -212,7 +211,7 @@ module.exports = {
         break;
     }
 
-    member.proto = helpers.inline(m);
+    member.proto = '```c++\n' + m.join("") + '\n```'
   },
 
   assignToNamespace: function (compound, child) {

--- a/src/templates.js
+++ b/src/templates.js
@@ -28,6 +28,8 @@ module.exports = {
         noEscape: true,
         strict: true
       });
+      let match = filename.match(/(.*)\.md$/)
+      console.log("trying to match ", filename, match)
       this.templates[filename.match(/(.*)\.md$/)[1]] = template;
     }.bind(this));
   },
@@ -50,7 +52,11 @@ module.exports = {
       case 'struct':
         template = 'class';
         break;
+      case 'dir':
+        template = 'dir';
+        break;
       default:
+        console.log("No template for kind ",compound.kind)
         return undefined;
     }
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -55,6 +55,9 @@ module.exports = {
       case 'dir':
         template = 'dir';
         break;
+      case 'function':
+        template = 'function';
+        break;
       default:
         console.log("No template for kind ",compound.kind)
         return undefined;

--- a/templates/cpp/dir.md
+++ b/templates/cpp/dir.md
@@ -1,18 +1,15 @@
 # {{kind}} `{{name}}` {{anchor refid}}
 
-{{briefdescription}}
-
-
 {{#each members}}
 
-# {{name}}
+{{name}}
 
 {{proto}}
-
-## Summary
 
 {{briefdescription}}
 
 {{detaileddescription}}
 
 {{/each}}
+
+YOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO

--- a/templates/cpp/function.md
+++ b/templates/cpp/function.md
@@ -1,0 +1,9 @@
+# {{name}}
+
+{{proto}}
+
+## Summary
+
+{{briefdescription}}
+
+{{detaileddescription}}

--- a/templates/cpp/function.md
+++ b/templates/cpp/function.md
@@ -1,5 +1,7 @@
 # {{name}}
 
+Defined in <`{{ location }}`>
+
 {{proto}}
 
 ## Summary


### PR DESCRIPTION
When parsing the documentation for a program that references external code, `this.references[innerclassdef.$.refid]` would return a null reference and would subsequently crash.

For example, when I use `std::array`, this would cause an issue because the XML generated would look something like this for `namespacestd.xml`:

```xml
<?xml version='1.0' encoding='UTF-8' standalone='no'?>
<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.8.5">
  <compounddef id="namespacestd" kind="namespace">
    <compoundname>std</compoundname>
    <innerclass refid="classstd_1_1allocator" prot="public">std::allocator</innerclass>
    <innerclass refid="classstd_1_1array" prot="public">std::array</innerclass>
     ...
   </compounddef>
</doxygen>
```

To prevent this, we can check to see if the reference exists first.
