### PR TITLE
Fixing issue with missing namespace reference

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -321,11 +321,14 @@ module.exports = {
           compounddef.innerclass.forEach(function (innerclassdef) {
               if (compound.kind == 'namespace') {
                 // log.verbose('Assign ' + innerclassdef.$.refid + ' to namespace ' + compound.name);
-                this.assignToNamespace(compound, this.references[innerclassdef.$.refid]);
+
+                if (this.references[innerclassdef.$.refid])
+                  this.assignToNamespace(compound, this.references[innerclassdef.$.refid]);
               }
               else if (compound.kind == 'group') {
                 // log.verbose('Assign ' + innerclassdef.$.refid + ' to group ' + compound.name);
-                this.assignClassToGroup(compound, this.references[innerclassdef.$.refid]);
+                if (this.references[innerclassdef.$.refid])
+                  this.assignClassToGroup(compound, this.references[innerclassdef.$.refid]);
               }
           }.bind(this));
         }


### PR DESCRIPTION
Second time's a charm.

When parsing the documentation for a program that references external code, `this.references[innerclassdef.$.refid]` would return a null reference and would subsequently crash.

For example, when I use `std::array`, this would cause an issue because the XML generated would look something like this for `namespacestd.xml`:

```xml
<?xml version='1.0' encoding='UTF-8' standalone='no'?>
<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.8.5">
  <compounddef id="namespacestd" kind="namespace">
    <compoundname>std</compoundname>
    <innerclass refid="classstd_1_1allocator" prot="public">std::allocator</innerclass>
    <innerclass refid="classstd_1_1array" prot="public">std::array</innerclass>
     ...
   </compounddef>
</doxygen>
```

To prevent this, we can check to see if the reference exists first.
