### PR TITLE
Fixing crash when XML file generated by doxygen fails to parse.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -366,7 +366,11 @@ module.exports = {
         log.verbose('Parsing ' + path.join(options.directory, compound.refid + '.xml'));
         doxygen = fs.readFileSync(path.join(options.directory, compound.refid + '.xml'), 'utf8');
         xmlParser.parseString(doxygen, function (err, data) {
-          this.parseCompound(compound, data.doxygen.compounddef[0]);
+          if (err) {
+            log.verbose('warning - parse error for file' , path.join(options.directory, compound.refid + '.xml'))
+            return;
+          }
+            this.parseCompound(compound, data.doxygen.compounddef[0]);
         }.bind(this));
       }
 


### PR DESCRIPTION
Sometimes, the files generated by Doxygen are not valid XML, especially when dealing with templates. For example, if your source contains something like:

```c++
boost::random::uniform_int_distribution<int>(...)
```

This may appear in the XML verbatim, and the `<int>` template parameter may be mistaken for the opening of an XML tag:

```xml
<bitfield> m_rng(seed)  { }  size_t operator()(size_t i)  {    return      boost::random::uniform_int_distribution<int>(0</bitfield>
```

Currently, when presented with this kind of behavior, moxygen will crash. Instead, we can
check if the parser fails to parse this file and simply avoid the file and emit a warning.