### PR TITLE
Fix links error

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,8 +23,10 @@ module.exports = {
           if (f.charAt(0) == '[') {
             // link
             var link = f.match(/\[(.*)\]\((.*)\)/);
-            isInline ? (s += '`') && (isInline = false) : null;
-            s += '[`' + link[1] + '`](' + link[2] + ')';
+            if (link) {
+              isInline ? (s += '`') && (isInline = false) : null;
+              s += '[`' + link[1] + '`](' + link[2] + ')';
+            }
           }
           else if (f == '\n' || f == '  \n') {
             // line break


### PR DESCRIPTION
I was hitting an error because some of my links were formed like so:

`[Click Here](#class_m_linky_link)[]` instead of the usual `[Click Here](#class_m_linky_link)`

No idea why, I'm new to Doxygen, nut I can see that when it ran through this part of the code the it would find that last `[]` and think it was a link resulting in the following error: `TypeError: Cannot read property '1' of null`.