### PR TITLE
Add exception parameterlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moxygen",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Doxygen XML to Markdown documentation converter",
   "main": "index.js",
   "scripts": {

--- a/src/parser.js
+++ b/src/parser.js
@@ -39,7 +39,15 @@ function toMarkdown(element, context) {
           case 'bold': s = '**'; break;
           case 'parametername':
           case 'computeroutput': s = '`'; break;
-          case 'parameterlist': s = '\n#### Parameters\n'; break;
+          case 'parameterlist':
+            if (element.$.kind == 'exception') {
+              s = '\n#### Exceptions\n'
+            }
+            else {
+              s = '\n#### Parameters\n'
+            }
+            break;
+
           case 'parameteritem': s = '* '; break;
           case 'programlisting': s = '\n```cpp\n'; break;
           case 'itemizedlist': s = '\n\n'; break;


### PR DESCRIPTION
Add `exception` parameter list to be able to use `@exception`, `@throw` or `@throws` and not be mislabeled as a `parameter`.