### PR TITLE
Fix linking to external file (e.g. if groups or classes options used).

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,17 +46,15 @@ module.exports = {
     }
   },
 
-  // Replace group links to point to correct output file
-  replaceGroupReflink: function (outfile, references, str) {
-    var match = str.match(/\((#(.*))\)/),
-      anchor = match[1],
-      refid = match[2],
-      ref = references[refid];
-    if (ref && ref.groupname) {
-      var href = util.format(outfile, ref.groupname) + anchor;
-      str = str.replace(/\((#(.*))\)/, '(' + href + ')')
-    }
-    return str;
+  // Replace group and class links to point to correct output file if needed
+  resolveRef: function(options, compound, references) {
+    return function(refid) {
+      if ((options.groups || options.classes) && compound.refid !== refid && references[refid]) {
+        return util.format(options.output, options.groups ? references[refid].groupname : references[refid].name) + '#' + refid;
+      } else {
+        return '#' + refid;
+      }
+    };
   },
 
   // Write the output file

--- a/src/templates.js
+++ b/src/templates.js
@@ -77,17 +77,11 @@ module.exports = {
 
     // Escape the code for a table cell.
     handlebars.registerHelper('cell', function(code) {
-      if (options.groups && code.indexOf('(#') !== -1) {
-        code = helpers.replaceGroupReflink(options.output, doxyparser.references, code);
-      }
       return code.replace(/\|/g, '\\|').replace(/\n/g, '<br/>');
     });
 
     // Escape the code for a titles.
     handlebars.registerHelper('title', function(code) {
-      if (options.groups && code.indexOf('(#') !== -1) {
-        code = helpers.replaceGroupReflink(options.output, doxyparser.references, code);
-      }
       return code.replace(/\n/g, '<br/>');
     });
 


### PR DESCRIPTION
Wasn't sure if this is the right way to do it, had to move some stuff around, but the problem it tries to fix is the external links not pointing to the right file when generating with `--groups` or `--classes`. It removes the "old fix", which was replacing the markdown links via the `title` and `cell` handlebars helpers (and thus did not cover links in descriptions/summary for example).