### PR TITLE
fix cpp file name

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -101,7 +101,7 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name);
+      return util.format(options.output, compound.name.replace(/\:/g, '-'));
     } else {
       return options.output;
     }


### PR DESCRIPTION
Fix invalid file names for C++ style names that have colons in them.

**Issue**: When try to use typenames as filenames for C++ files, moxygen outputs an Error: ENOENT: no such file or directory.

**Fix**: This change replaces ":" with "-".