### PR TITLE
Treat interface compounds (e.g. keyword "interface" in C#) like classes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
         'struct',
         'union',
         'typedef',
+        'interface',
         // 'file'
       ]
     }

--- a/src/templates.js
+++ b/src/templates.js
@@ -55,6 +55,7 @@ module.exports = {
         break;
       case 'class':
       case 'struct':
+      case 'interface':
         template = 'class';
         break;
       default:


### PR DESCRIPTION
Right now, C# interfaces are just ignored. But we can treat them exactly like classes and get useful output.