### PR TITLE
fixed fileName for templated classes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -101,7 +101,7 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:/g, '-'));
+      return util.format(options.output, compound.name.replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
     } else {
       return options.output;
     }


### PR DESCRIPTION
I ran into a problem for templated classes, where doxygen generates names containing '<' and '>' for the template type. The generation of the fileName fails for those files, because < and > are not valid in file names. This PR replaces those symbols with '(' for '<' and ')' for '>'.