### PR TITLE
Adding a custom separator option for replacing the default '::' in filenames

### DIFF
--- a/bin/moxygen.js
+++ b/bin/moxygen.js
@@ -20,13 +20,15 @@ program.version(pjson.version)
   .option('-t, --templates <dir>', 'custom templates directory (default: "built-in templates")', String)
   .option('-L, --logfile [file]', 'output log messages to file, (default: console only, default file name: "moxygen.log")')
   .option('-q, --quiet', 'quiet mode', false)
+  .option('-s, --separator <separator sequence>', 'separator sequence (default: "::")', '::')
+
   .parse(process.argv);
 
 logger.init(program, app.defaultOptions);
 
 if (program.args.length) {
   app.run(assign({}, app.defaultOptions, {
-    directory: program.args[0],
+    directory: program.args.slice(-1).pop(),
     output: program.output,
     groups: program.groups,
     pages: program.pages,
@@ -35,6 +37,7 @@ if (program.args.length) {
     anchors: program.anchors,
     htmlAnchors: program.htmlAnchors,
     language: program.language,
+    separator: program.separator,
     templates: program.templates,
   }));
 }

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
     classes: false,             /** Output doxygen classes separately **/
     output_s: 'api_%s.md',      /** Output file for groups and classes **/
     logfile: 'moxygen.log',     /** Log file **/
+    separator: '::',            /** Group separator sequence **/
 
     filters: {
       members: [

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -101,7 +101,7 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
+      return util.format(options.output, compound.name.replace(/\:\:/g, options.separator).replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
     } else {
       return options.output;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -429,7 +429,7 @@ module.exports = {
       case 'typedef':
 
         // set namespace reference
-        var nsp = compound.name.split('::');
+        var nsp = compound.name.split("::");
         compound.namespace = nsp.splice(0, nsp.length - 1).join('::');
         break;
 


### PR DESCRIPTION
The '::' sequence was driving my windows machine crazy, so I added an option with flag -s/--separator to replace it with something else in the actual filenames. It also created a conflict with the way the directory was specified (since it wouldn't be the arg[0] anymore), so I made a small change to instead grab the last argument specified instead. 