### PR TITLE
Added option to create relative links

### DIFF
--- a/bin/moxygen.js
+++ b/bin/moxygen.js
@@ -20,13 +20,15 @@ program.version(pjson.version)
   .option('-t, --templates <dir>', 'custom templates directory (default: "built-in templates")', String)
   .option('-L, --logfile [file]', 'output log messages to file, (default: console only, default file name: "moxygen.log")')
   .option('-q, --quiet', 'quiet mode', false)
+  .option('-s, --separator <separator sequence>', 'separator sequence (default: "::")', '::')
+
   .parse(process.argv);
 
 logger.init(program, app.defaultOptions);
 
 if (program.args.length) {
   app.run(assign({}, app.defaultOptions, {
-    directory: program.args[0],
+    directory: program.args.slice(-1).pop(),
     output: program.output,
     groups: program.groups,
     pages: program.pages,
@@ -35,6 +37,7 @@ if (program.args.length) {
     anchors: program.anchors,
     htmlAnchors: program.htmlAnchors,
     language: program.language,
+    separator: program.separator,
     templates: program.templates,
   }));
 }

--- a/bin/moxygen.js
+++ b/bin/moxygen.js
@@ -20,6 +20,7 @@ program.version(pjson.version)
   .option('-t, --templates <dir>', 'custom templates directory (default: "built-in templates")', String)
   .option('-L, --logfile [file]', 'output log messages to file, (default: console only, default file name: "moxygen.log")')
   .option('-q, --quiet', 'quiet mode', false)
+  .option('-r, --relative-paths', 'links are relative (don`t include the output path)', false)
   .option('-s, --separator <separator sequence>', 'separator sequence (default: "::")', '::')
 
   .parse(process.argv);
@@ -37,6 +38,7 @@ if (program.args.length) {
     anchors: program.anchors,
     htmlAnchors: program.htmlAnchors,
     language: program.language,
+    relativePaths: program.relativePaths,
     separator: program.separator,
     templates: program.templates,
   }));

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
     classes: false,             /** Output doxygen classes separately **/
     output_s: 'api_%s.md',      /** Output file for groups and classes **/
     logfile: 'moxygen.log',     /** Log file **/
+    relativePaths: false,       /** Use relative paths (omit output base path) **/
     separator: '::',            /** Group separator sequence **/
 
     filters: {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
     classes: false,             /** Output doxygen classes separately **/
     output_s: 'api_%s.md',      /** Output file for groups and classes **/
     logfile: 'moxygen.log',     /** Log file **/
+    separator: '::',            /** Group separator sequence **/
 
     filters: {
       members: [

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -101,7 +101,7 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
+      return util.format(options.output, compound.name.replace(/\:\:/g, options.separator).replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
     } else {
       return options.output;
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -101,14 +101,22 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:\:/g, options.separator).replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
+      var target = options.output;
+      if (options.relativePaths) {
+	target = target.replace(target, path.basename(target));
+      }
+      return util.format(target, compound.name.replace(/\:\:/g, options.separator).replace(/\:/g, '-').replace('<', '(').replace('>', ')'));
     } else {
       return options.output;
     }
   },
 
   writeCompound: function(compound, contents, references, options) {
-    this.writeFile(this.compoundPath(compound, options), contents.map(function(content) {
+    var outputPath = this.compoundPath(compound, options);
+    if (options.relativePaths) {
+      outputPath = path.join(path.dirname(options.output), outputPath);
+    }
+    this.writeFile(outputPath, contents.map(function(content) {
       return this.resolveRefs(content, compound, references, options);
     }.bind(this)));
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -429,7 +429,7 @@ module.exports = {
       case 'typedef':
 
         // set namespace reference
-        var nsp = compound.name.split('::');
+        var nsp = compound.name.split("::");
         compound.namespace = nsp.splice(0, nsp.length - 1).join('::');
         break;
 


### PR DESCRIPTION
My wiki had trouble navigating the created links between class pages, so I added the option (-r, --relative-paths) to strip the output path from links, allowing truly relative navigation no matter where the files are published. May need to be tweaked if some form of directory support is added in the future.