### PR TITLE
Fix duplicated detaileddescription section titles

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -125,8 +125,8 @@ function toMarkdown(element: unknown, context: XmlElement[] = []): string {
       break;
     case 'title': {
       const level = '#'.repeat(Number(context[context.length - 1]?.['#name']?.slice(-1) ?? '1'));
-      s = `\n#${level} ${el._ ?? ''}\n`;
-      break;
+      const title = trim(el.$$ ? toMarkdown(el.$$, context) : (el._ ?? ''));
+      return `\n#${level} ${title}\n`;
     }
     case 'mdash':
       s = '&mdash;';

--- a/test/fixtures/title-duplication/xml-out/xml/index.xml
+++ b/test/fixtures/title-duplication/xml-out/xml/index.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygenindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd" version="1.9.8" xml:lang="en-US">
+  <compound refid="namespacedemo" kind="namespace"><name>demo</name>
+  </compound>
+</doxygenindex>

--- a/test/fixtures/title-duplication/xml-out/xml/namespacedemo.xml
+++ b/test/fixtures/title-duplication/xml-out/xml/namespacedemo.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.9.8" xml:lang="en-US">
+  <compounddef id="namespacedemo" kind="namespace" language="C++">
+    <compoundname>demo</compoundname>
+    <briefdescription>
+      <para>Namespace used to reproduce duplicated section headings.</para>
+    </briefdescription>
+    <detaileddescription>
+      <sect1 id="namespacedemo_1autotoc_md0">
+        <title>Requirements</title>
+        <sect2 id="namespacedemo_1autotoc_md1">
+          <title>Windows</title>
+          <para>Supported on Windows 11.</para>
+        </sect2>
+      </sect1>
+    </detaileddescription>
+    <location file="src/demo.hpp" line="1" column="1"/>
+  </compounddef>
+</doxygen>

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,6 +9,7 @@ const fileGroupedXmlDir = join(import.meta.dirname, 'fixtures', 'file-grouped', 
 const fileGroupedSourceDir = join(import.meta.dirname, 'fixtures', 'file-grouped', 'src');
 const sharedGroupedXmlDir = join(import.meta.dirname, 'fixtures', 'shared-grouped', 'xml-out', 'xml');
 const sharedGroupedSourceDir = join(import.meta.dirname, 'fixtures', 'shared-grouped', 'src');
+const titleDuplicationXmlDir = join(import.meta.dirname, 'fixtures', 'title-duplication', 'xml-out', 'xml');
 const ungroupedXmlDir = join(import.meta.dirname, 'fixtures', 'ungrouped', 'xml-out', 'xml');
 
 const exampleOutputDir = join(outputRoot, 'example');
@@ -242,5 +243,22 @@ describe('integration', () => {
     expect(content).toContain('Bicycle');
     expect(content).toContain('MountainBike');
     expect(content).toContain('RacingBike');
+  });
+
+  it('does not duplicate Doxygen section titles into the section body', async () => {
+    const outputDir = join(outputRoot, 'title-duplication');
+
+    await run({
+      directory: titleDuplicationXmlDir,
+      output: join(outputDir, '%s.md'),
+      classes: true,
+      anchors: false,
+      quiet: true,
+    });
+
+    const content = read(join(outputDir, 'demo.md')).replace(/\r\n/g, '\n');
+    expect(content).toContain('## Requirements\n\n### Windows\nSupported on Windows 11.');
+    expect(content).not.toContain('## Requirements\nRequirements');
+    expect(content).not.toContain('### Windows\nWindowsSupported on Windows 11.');
   });
 });


### PR DESCRIPTION
Fix #90 duplicated section title text when rendering Doxygen section `title` nodes from `detaileddescription` to Markdown.

Previously, section `title` output was written from `el._`, then rendered again via the generic child recursion because `xml2js` also exposes the same text as a `__text__` child in `el.$$`.

This change renders section title text exactly once and adds a regression test covering section headings generated from Doxygen XML.