### PR TITLE
fix(parser): programlisting language + namespace path collapse

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -224,7 +224,7 @@ export function compoundPath(compound: Compound, options: MoxygenOptions): strin
   if (options.classes) {
     return utilFormat(
       options.output,
-      compound.name.replace(/:/g, '-').replace('<', '(').replace('>', ')'),
+      compound.name.replace(/::/g, '-').replace('<', '(').replace('>', ')'),
     );
   }
   return options.output;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -63,9 +63,11 @@ function toMarkdown(element: unknown, context: XmlElement[] = []): string {
     case 'parameteritem':
       s = '* ';
       break;
-    case 'programlisting':
-      s = '\n```cpp\n';
+    case 'programlisting': {
+      const lang = el.$?.filename?.match(/\.([a-z0-9]+)$/i)?.[1] ?? 'cpp';
+      s = `\n\`\`\`${lang}\n`;
       break;
+    }
     case 'orderedlist':
       context.push(el);
       s = '\n\n';

--- a/test/fixtures/programlisting-language/xml-out/xml/index.xml
+++ b/test/fixtures/programlisting-language/xml-out/xml/index.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygenindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd" version="1.9.8" xml:lang="en-US">
+  <compound refid="namespacedemo" kind="namespace"><name>demo</name>
+  </compound>
+</doxygenindex>

--- a/test/fixtures/programlisting-language/xml-out/xml/namespacedemo.xml
+++ b/test/fixtures/programlisting-language/xml-out/xml/namespacedemo.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.9.8" xml:lang="en-US">
+  <compounddef id="namespacedemo" kind="namespace" language="C++">
+    <compoundname>demo</compoundname>
+    <briefdescription>
+      <para>Namespace used to verify programlisting language detection.</para>
+    </briefdescription>
+    <detaileddescription>
+      <para><programlisting filename=".py"><codeline><highlight class="normal">print(<sp/></highlight><highlight class="stringliteral">&quot;hello&quot;</highlight><highlight class="normal">)</highlight></codeline>
+</programlisting></para>
+    </detaileddescription>
+    <location file="src/demo.hpp" line="1" column="1"/>
+  </compounddef>
+</doxygen>

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   findParent,
   stripMarkdownLinks,
   buildCleanAnchorMap,
+  compoundPath,
   resolveRefs,
 } from '../src/helpers.js';
 import { createCompound } from '../src/compound.js';
@@ -209,6 +210,19 @@ describe('helpers', () => {
       );
 
       expect(resolved).toContain('[Widget](demo-Widget.html#widget-1)');
+    });
+  });
+
+  describe('compoundPath', () => {
+    it('collapses namespace separators into a single dash', () => {
+      const compound = createCompound(null, 'classicy_1_1wrtc_1_1MediaBridge', 'icy::wrtc::MediaBridge');
+      compound.kind = 'class';
+
+      const options = makeOptions('/tmp/docs/%s.md');
+      options.classes = true;
+      options.groups = false;
+
+      expect(compoundPath(compound, options)).toBe('/tmp/docs/icy-wrtc-MediaBridge.md');
     });
   });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -10,6 +10,7 @@ const fileGroupedSourceDir = join(import.meta.dirname, 'fixtures', 'file-grouped
 const sharedGroupedXmlDir = join(import.meta.dirname, 'fixtures', 'shared-grouped', 'xml-out', 'xml');
 const sharedGroupedSourceDir = join(import.meta.dirname, 'fixtures', 'shared-grouped', 'src');
 const ungroupedXmlDir = join(import.meta.dirname, 'fixtures', 'ungrouped', 'xml-out', 'xml');
+const programlistingLangXmlDir = join(import.meta.dirname, 'fixtures', 'programlisting-language', 'xml-out', 'xml');
 
 const exampleOutputDir = join(outputRoot, 'example');
 
@@ -115,15 +116,15 @@ describe('integration', () => {
     });
 
     const namespacePath = join(outputDir, 'demo.md');
-    const classPath = join(outputDir, 'demo--Plain.md');
+    const classPath = join(outputDir, 'demo-Plain.md');
 
     expect(existsSync(namespacePath), 'demo.md should exist').toBe(true);
-    expect(existsSync(classPath), 'demo--Plain.md should exist').toBe(true);
+    expect(existsSync(classPath), 'demo-Plain.md should exist').toBe(true);
 
     const namespaceContent = read(namespacePath);
     expect(namespaceContent).toContain('# demo');
     expect(namespaceContent).toContain('namespace-scoped type for ungrouped rendering.');
-    expect(namespaceContent).toContain('demo--Plain.md#plain');
+    expect(namespaceContent).toContain('demo-Plain.md#plain');
 
     const classContent = read(classPath);
     expect(classContent).toContain('## Plain');
@@ -222,9 +223,25 @@ describe('integration', () => {
       frontmatter: true,
     });
 
-    const content = read(join(outputDir, 'demo--PeerSession.md'));
+    const content = read(join(outputDir, 'demo-PeerSession.md'));
     expect(content)
-      .toContain('description: "Session type documented in a different group from [PacketStream](demo--PacketStream.md#packetstream)."');
+      .toContain('description: "Session type documented in a different group from [PacketStream](demo-PacketStream.md#packetstream)."');
+  });
+
+  it('uses programlisting filename extension as the code fence language', async () => {
+    const outputDir = join(outputRoot, 'programlisting-language');
+
+    await run({
+      directory: programlistingLangXmlDir,
+      output: join(outputDir, '%s.md'),
+      classes: true,
+      anchors: false,
+      quiet: true,
+    });
+
+    const content = read(join(outputDir, 'demo.md')).replace(/\r\n/g, '\n');
+    expect(content).toContain('```py');
+    expect(content).not.toContain('```cpp');
   });
 
   it('generates single file output', async () => {


### PR DESCRIPTION
## Summary

- **#52** — `<programlisting>` was hardcoded to a `cpp` fence. Now reads the optional `filename` attribute Doxygen emits (e.g. `.py`, `.java`) and uses its extension as the fence language; falls back to `cpp` when absent.
- **#53** — `compoundPath` was emitting `namespace--class.md` because it replaced single `:` with `-`, causing each `:` in `::` to become its own dash. Now collapses `::` to a single `-`, matching the slug convention used in `cleanId` and `slugify`.

Updated two existing integration assertions that pinned the buggy `--` filename.

## Test plan

- [x] `npm test` — 49/49 pass (was 47, +1 unit test for `compoundPath`, +1 integration test for programlisting language)
- [x] New fixture under `test/fixtures/programlisting-language/` mirrors the `\code{.py}` Doxygen pattern