### PR TITLE
Implement a new -I, --inline-groups command line option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ program
   .option('-s, --source-root <dir>', 'source root used to resolve file-level group membership')
   .option('-f, --frontmatter', 'prepend YAML frontmatter to output files', false)
   .option('-L, --logfile [file]', 'output log messages to file (default: "moxygen.log")')
+  .option('-I, --inline-groups', 'inline group members into the parent compound instead of generating separate files', false)
   .option('-q, --quiet', 'quiet mode', false)
   .action(async (directory: string, opts: Record<string, unknown>) => {
     try {
@@ -45,6 +46,7 @@ program
         frontmatter: opts.frontmatter as boolean,
         logfile: opts.logfile as string | boolean | undefined,
         quiet: opts.quiet as boolean,
+        inlineGroups: opts.inlineGroups as boolean,
       });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export const defaultOptions: MoxygenOptions = {
   quiet: false,
   frontmatter: false,
   filters: defaultFilters,
+  inlineGroups: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -962,6 +963,21 @@ export async function run(options: Partial<MoxygenOptions> & { directory: string
     }
   } else {
     const compounds = toFilteredArray(root, 'compounds');
+    if (opts.inlineGroups) {
+      const groups = (toArray(root, 'compounds', 'group') as Compound[])
+        .filter((g) => !isJunkCompound(g));
+      if (groups.length) {
+        augmentGroupsFromFiles(root, groups, opts); // to prepare
+        finalizeGroups(groups, collectSharedNamespaceRefs(toArray(root, 'compounds', 'file') as Compound[], opts));
+        for (const group of groups) {
+          filterChildren(group, opts.filters, group.id);
+          prepareCompound(group);
+          const childCompounds = toFilteredArray(group, 'compounds');
+          for (const c of childCompounds) prepareCompound(c);
+          compounds.push(group, ...childCompounds); // or insert at top or structured
+        }
+      }
+    }
     if (!opts.noindex) {
       compounds.unshift(root);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface MoxygenOptions {
   quiet: boolean;
   frontmatter: boolean;
   filters: Filters;
+  inlineGroups: boolean;
 }
 
 export interface Filters {


### PR DESCRIPTION
when specified, this will append all group data to the output file if --groups is not specified.