### PR TITLE
Issue 117: Moxygen always skips macros that lack documentation

### DIFF
--- a/src/compound.ts
+++ b/src/compound.ts
@@ -223,7 +223,6 @@ const NOISE_RE = /^(TYPE|BREAK|DEG|SEP|IMPL)_\d+$/;
  */
 export function filterNoise(members: Member[]): Member[] {
   return members.filter((m) => {
-    if (m.section === 'define' && !m.briefdescription && !m.detaileddescription) return false;
     if (m.name.startsWith('~') && !m.briefdescription && !m.detaileddescription) return false;
     if (NOISE_RE.test(m.name)) return false;
     if (m.name === 'operator=' && !m.briefdescription && !m.detaileddescription) return false;

--- a/test/compound.test.ts
+++ b/test/compound.test.ts
@@ -225,14 +225,15 @@ describe('compound', () => {
   });
 
   describe('filterNoise', () => {
-    it('drops undocumented macros but keeps documented ones', () => {
+    it('keeps undocumented macros and keeps documented ones', () => {
       const undocumented = makeMember('HTTP_API', 'define');
       const documented = makeMember('DECLARE_THING', 'define');
       documented.briefdescription = 'Macro docs';
 
       const result = filterNoise([undocumented, documented]);
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('DECLARE_THING');
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('HTTP_API');
+      expect(result[1].name).toBe('DECLARE_THING');
     });
   });
 });


### PR DESCRIPTION
Moxygen considers undocumented macros "noise". But, if doxygen went into the trouble of documenting these, they should not be treated as noise and filtered.

Removed the line that was doing the filtering.
Updated the regression test to cover that.