### PR TITLE
ci: drive releases from package.json version and guard drifting surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,10 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm test
+
+      # example/doc is committed output. Regenerating it must be a no-op, or
+      # the published example is describing behaviour the code no longer has.
+      - name: Verify committed example output is current
+        run: |
+          npm run example
+          git diff --exit-code -- example/doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,20 @@
 name: Release
 
+# Releases are driven by the version in package.json, not by remembering to
+# tag. Land a bump on main and the tag, GitHub release and npm publish follow.
+# Every other push to main resolves to a no-op in seconds.
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Release even though the tag already exists, to finish a partial release
+        type: boolean
+        default: false
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -16,6 +24,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      release: ${{ steps.version.outputs.release }}
 
     steps:
       - uses: actions/checkout@v7
@@ -26,36 +35,64 @@ jobs:
           cache: npm
 
       - id: version
-        name: Verify package version matches tag
+        name: Decide whether this commit releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -eu
-          version="${GITHUB_REF_NAME#v}"
-          node -e '
-            const pkg = require("./package.json");
-            const expected = process.argv[1];
-            if (pkg.version !== expected) {
-              console.error(`package.json version ${pkg.version} does not match tag ${expected}`);
-              process.exit(1);
-            }
-          ' "$version"
+          version="$(node -p 'require("./package.json").version')"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
+          lock_version="$(node -p 'require("./package-lock.json").version')"
+          if [ "$lock_version" != "$version" ]; then
+            echo "package-lock.json is at $lock_version but package.json is at $version." >&2
+            echo "Bump with 'npm version <patch|minor|major>' so both stay in step." >&2
+            exit 1
+          fi
 
-      - name: Pack npm artifact
+          if [ "${FORCE:-false}" = "true" ]; then
+            echo "Forced run: releasing v$version even if the tag exists."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          elif gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${version}" >/dev/null 2>&1; then
+            echo "v$version is already released; nothing to do."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "v$version is not released yet."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Before the expensive steps, so a missing changelog entry fails fast.
+      - if: steps.version.outputs.release == 'true'
+        name: Extract release notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           mkdir -p .stage/release
-          npm pack --pack-destination .stage/release
+          node scripts/changelog-section.mjs "$VERSION" > .stage/release/notes.md
 
-      - uses: actions/upload-artifact@v7
+      - if: steps.version.outputs.release == 'true'
+        run: npm ci
+
+      - if: steps.version.outputs.release == 'true'
+        run: npm run build
+
+      - if: steps.version.outputs.release == 'true'
+        run: npm test
+
+      - if: steps.version.outputs.release == 'true'
+        name: Pack npm artifact
+        run: npm pack --pack-destination .stage/release
+
+      - if: steps.version.outputs.release == 'true'
+        uses: actions/upload-artifact@v7
         with:
           name: moxygen-npm-package
-          path: .stage/release/moxygen-*.tgz
+          path: .stage/release
 
   github-release:
     needs: validate
+    if: needs.validate.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -66,14 +103,17 @@ jobs:
           name: moxygen-npm-package
           path: .stage/release
 
-      - name: Create GitHub release
+      - name: Create tag and GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          generate_release_notes: true
+          tag_name: v${{ needs.validate.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          body_path: .stage/release/notes.md
           files: .stage/release/moxygen-*.tgz
 
   publish-npm:
-    needs: validate
+    needs: [validate, github-release]
+    if: needs.validate.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+.test-output*/
+.stage/
 npm-debug.log
 *.tsbuildinfo
 .sourcey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+Notable changes per release. Older history is in the git log.
+
+## 2.1.13 - 2026-08-27
+
+### Fixed
+
+- Macros render by their real shape. Function-like macros keep their parameters, object-like macros no longer gain empty parens, and both show their initializer. Thanks to @gkodinov for the report and the parser fix.
+- Group pages keep their detailed description instead of collapsing to the brief. Applies to both the cpp and java templates.
+- Unnamed function parameters keep their type in signatures.
+- Parameter tables no longer render empty backticks for parameters that have no type, which is every macro parameter.
+
+### Changed
+
+- Undocumented members are no longer dropped. Doxygen only emits a member when the project asked for it, by documenting it, by placing it in a documented group, or by setting `EXTRACT_ALL`, so filtering on missing documentation was overriding an explicit choice. **Projects running `EXTRACT_ALL = YES` will see more members in their output than on 2.1.12.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+## Development
+
+```bash
+npm install
+npm run build     # tsc
+npm run lint      # tsc --noEmit
+npm test          # vitest run
+```
+
+CI runs build, lint and tests on Node 20, 22 and 24, and checks that the
+committed example output is current.
+
+## Committed generated output
+
+Two kinds of generated files are committed, and they are checked differently.
+
+**`example/doc/`** is Markdown rendered from `example/xml`. Regenerate with
+`npm run example` after any change that affects output, and commit the result.
+CI fails if regenerating produces a diff, so this cannot drift silently.
+
+**`test/fixtures/*/xml-out/`** is Doxygen XML. Different Doxygen versions emit
+different schema boilerplate, so regenerating with the wrong version buries a
+real change in unrelated churn. Use:
+
+```bash
+npm run fixtures                  # list fixtures and the version each needs
+npm run fixtures -- global-groups # regenerate one
+```
+
+The script refuses to run when the installed Doxygen does not match the version
+that produced that fixture. Pass `--allow-version-change` when the bump is
+deliberate.
+
+Five fixtures (`member-kinds`, `missing-tags`, `programlisting-language`,
+`title-disambiguation`, `title-duplication`) have no Doxyfile or sources. Their
+XML is hand authored to reach shapes Doxygen will not emit on demand, and it is
+edited directly.
+
+## Templates
+
+`templates/cpp/` and `templates/java/` are near-identical. `namespace.md` and
+`index.md` must stay in step apart from the code fence language, and
+`test/template-parity.test.ts` enforces that. A fix to one is a fix to both.
+`class.md` diverges on purpose.
+
+## Releasing
+
+Releases are driven by the version in `package.json`. There is no separate
+tagging step.
+
+1. Add the entry to `CHANGELOG.md` under a `## <version>` heading.
+2. `npm version patch` (or `minor` / `major`) with no git tag:
+   `npm version patch --no-git-tag-version`. This keeps `package.json` and
+   `package-lock.json` in step; the release refuses to run if they disagree.
+3. Commit as `Bump version to <version>` and merge to `main`.
+
+Landing that on `main` runs the release workflow, which validates, tags
+`v<version>`, creates the GitHub release using the changelog section as its
+notes, and publishes to npm with provenance. Every other push to `main`
+resolves to a no-op in seconds.
+
+A release cannot ship without a changelog entry: the workflow fails early when
+the section is missing.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build",
-    "example": "npm run build && node dist/cli.js --groups --pages --anchors --output=example/doc/api-%s.md example/xml"
+    "example": "npm run build && node dist/cli.js --groups --pages --anchors --output=example/doc/api-%s.md example/xml",
+    "fixtures": "node scripts/regen-fixture.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/changelog-section.mjs
+++ b/scripts/changelog-section.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Print the CHANGELOG section for one version, for use as GitHub release notes.
+// Exits non-zero when the section is missing, so a release cannot ship
+// undocumented.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const version = process.argv[2];
+if (!version) {
+  console.error('usage: changelog-section.mjs <version>');
+  process.exit(1);
+}
+
+const changelogPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'CHANGELOG.md');
+const lines = readFileSync(changelogPath, 'utf8').split('\n');
+
+const isVersionHeading = (line) => /^## /.test(line);
+const start = lines.findIndex((line) => isVersionHeading(line) && line.slice(3).trim().startsWith(version));
+
+if (start === -1) {
+  console.error(`CHANGELOG.md has no "## ${version}" section.`);
+  console.error('Add the entry before releasing, so the notes describe the change.');
+  process.exit(1);
+}
+
+const rest = lines.slice(start + 1);
+const end = rest.findIndex(isVersionHeading);
+const body = (end === -1 ? rest : rest.slice(0, end)).join('\n').trim();
+
+if (!body) {
+  console.error(`The "## ${version}" section in CHANGELOG.md is empty.`);
+  process.exit(1);
+}
+
+console.log(body);

--- a/scripts/regen-fixture.mjs
+++ b/scripts/regen-fixture.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Regenerate one fixture's Doxygen XML.
+//
+// Fixtures are committed Doxygen output, and different Doxygen versions emit
+// different schema boilerplate. Regenerating with the wrong version buries a
+// real change in hundreds of lines of unrelated churn, so this refuses to run
+// unless the local Doxygen matches the version that produced the fixture.
+//
+// Five fixtures have no Doxyfile or sources at all. Their XML is hand authored
+// to reach shapes Doxygen will not emit on demand, and it must be edited by
+// hand. This script names them rather than pretending they are reproducible.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureRoot = join(root, 'test', 'fixtures');
+
+/** Fixture directory plus the location of its generated index.xml. */
+function targets() {
+  const found = new Map([['example', { dir: join(root, 'example'), index: join(root, 'example', 'xml', 'index.xml') }]]);
+  for (const name of readdirSync(fixtureRoot)) {
+    const dir = join(fixtureRoot, name);
+    found.set(name, { dir, index: join(dir, 'xml-out', 'xml', 'index.xml') });
+  }
+  return found;
+}
+
+/** The Doxygen version recorded in generated XML, e.g. 1.17.0. */
+function recordedVersion(indexPath) {
+  if (!existsSync(indexPath)) return undefined;
+  return readFileSync(indexPath, 'utf8').match(/version="([^"]+)"/)?.[1];
+}
+
+function localVersion() {
+  try {
+    return execFileSync('doxygen', ['--version'], { encoding: 'utf8' }).trim().split(/\s+/)[0];
+  } catch {
+    return undefined;
+  }
+}
+
+const all = targets();
+const name = process.argv[2];
+const allowVersionChange = process.argv.includes('--allow-version-change');
+
+if (!name || !all.has(name)) {
+  const rows = [...all.entries()].map(([key, { dir, index }]) => {
+    const reproducible = existsSync(join(dir, 'Doxyfile'));
+    const version = recordedVersion(index) ?? 'unknown';
+    return `  ${key.padEnd(26)} ${reproducible ? `doxygen ${version}` : 'hand authored, edit directly'}`;
+  });
+  console.error('usage: npm run fixtures -- <name> [--allow-version-change]\n');
+  console.error(rows.join('\n'));
+  process.exit(name ? 1 : 0);
+}
+
+const { dir, index } = all.get(name);
+
+if (!existsSync(join(dir, 'Doxyfile'))) {
+  console.error(`${name} has no Doxyfile. Its XML is hand authored and must be edited directly.`);
+  process.exit(1);
+}
+
+const local = localVersion();
+if (!local) {
+  console.error('doxygen is not on PATH.');
+  process.exit(1);
+}
+
+const recorded = recordedVersion(index);
+if (recorded && recorded !== local && !allowVersionChange) {
+  console.error(`${name} was generated with doxygen ${recorded}, but ${local} is installed.`);
+  console.error('Regenerating now would mix schema churn into the diff.');
+  console.error(`Install doxygen ${recorded}, or pass --allow-version-change if the bump is intended.`);
+  process.exit(1);
+}
+
+execFileSync('doxygen', ['Doxyfile'], { cwd: dir, stdio: 'inherit' });
+console.log(`Regenerated ${name} with doxygen ${local}.`);

--- a/test/template-parity.test.ts
+++ b/test/template-parity.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { run } from '../src/index.js';
+
+const templateRoot = join(import.meta.dirname, '..', 'templates');
+const globalGroupsXmlDir = join(import.meta.dirname, 'fixtures', 'global-groups', 'xml-out', 'xml');
+// Its own root: test files run in parallel, and the integration suite removes
+// .test-output wholesale when it finishes.
+const outputRoot = join(import.meta.dirname, '..', '.test-output-parity');
+
+afterAll(() => {
+  if (existsSync(outputRoot)) {
+    rmSync(outputRoot, { recursive: true });
+  }
+});
+
+const read = (language: string, name: string) => readFileSync(join(templateRoot, language, name), 'utf8');
+
+/** The fence language is the only intended difference between these files. */
+const ignoreFenceLanguage = (template: string) => template.replace(/```(cpp|java)/g, '```lang');
+
+describe('template parity', () => {
+  // class.md diverges on purpose: Java has no header includes and different
+  // member kinds. These two do not, and a fix applied to one of them silently
+  // leaving the other behind is a drift this pins down.
+  for (const name of ['namespace.md', 'index.md']) {
+    it(`keeps cpp and java ${name} in step`, () => {
+      expect(ignoreFenceLanguage(read('java', name))).toBe(ignoreFenceLanguage(read('cpp', name)));
+    });
+  }
+
+  it('renders group descriptions through the java templates too', async () => {
+    const outputDir = join(outputRoot, 'java-groups');
+
+    await run({
+      directory: globalGroupsXmlDir,
+      output: join(outputDir, '%s.md'),
+      language: 'java',
+      groups: true,
+      anchors: true,
+      quiet: true,
+    });
+
+    const group = readFileSync(join(outputDir, 'global_group.md'), 'utf8');
+    expect(group).toContain('The group holding global entities.');
+    expect(group).toContain("This is the global group's description.");
+    expect(group).not.toContain('## Description');
+  });
+});


### PR DESCRIPTION
Removes the guesswork around releases, and pins the surfaces that were drifting silently.

### Releases are version-driven

`release.yml` now triggers on pushes to `main` and decides from `package.json`, rather than waiting for someone to remember a tag. Land a bump and the tag, GitHub release and npm publish follow. Any other push resolves to a no-op in seconds.

It also fails when `package.json` and `package-lock.json` disagree, and `workflow_dispatch` takes a `force` input so a partial release can be finished without hand-editing tags.

### CHANGELOG drives release notes

`generate_release_notes` derives notes from PR titles, which cannot express something like "undocumented members now appear for EXTRACT_ALL projects". Notes now come from the matching `CHANGELOG.md` section, and the release fails early when the section is missing, so a release cannot ship undocumented.

### Committed example output is now a CI gate

`example/doc` had been stale since d506920 and 9bd19ae, and nothing noticed. CI regenerates it and fails on a diff.

### Fixture regeneration is version-aware

The fixtures were generated by four different Doxygen versions (1.8.14, 1.9.8, 1.17.0, and one hand-authored set). Regenerating with the wrong one buries the real change in schema churn. `npm run fixtures` lists what each needs and refuses to run on a mismatch.

Five fixtures have no Doxyfile or sources at all. The script names them rather than pretending they are reproducible.

### Template parity is pinned

`templates/cpp/namespace.md` and `templates/java/namespace.md` differ by exactly one line, the fence language, and the same holds for `index.md`. That is why #121 fixed cpp and left java behind. `test/template-parity.test.ts` now fails if they diverge.

### CONTRIBUTING.md

The runbook that was missing: dev commands, which generated output is checked how, the template rule, and the release steps.

---

Merging this is a no-op for the release workflow: `package.json` is 2.1.13 and `v2.1.13` already exists, so it resolves to `release=false`.