### PR TITLE
Bump version to 2.1.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,16 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # Majors stay out of the group so they arrive as individual PRs. The
+      # first grouped run swept commander, TypeScript and vitest majors into
+      # one PR, which is not something to review as a batch.
       npm-versions:
         applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
       npm-security:
         applies-to: security-updates
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable changes per release. Older history is in the git log.
 
+## 2.1.14 - 2026-08-27
+
+### Changed
+
+- `commander` moved to ^15.0.0. New installs resolve a different major of the CLI argument parser, verified against the full CLI surface: help, version, every flag, `%s` output patterns and the missing-argument error path.
+- Development dependencies moved to TypeScript ^7.0.2, vitest ^4.1.11 and @types/node ^26.2.0.
+
+No change to generated output.
+
 ## 2.1.13 - 2026-08-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moxygen",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moxygen",
-      "version": "2.1.13",
+      "version": "2.1.14",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moxygen",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Doxygen XML to Markdown converter",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Ships the dependency group merged in #123, and keeps majors out of future grouped PRs.

The grouped run swept commander, TypeScript and vitest majors into one PR. CI passing did not cover that, because no test imports `src/cli.ts` and commander is what drives it. Verified directly instead, against commander 15: `--help`, `--version`, every flag, `%s` output patterns, and the missing-argument error path, with output byte-identical to the committed example.

`dependabot.yml` now restricts the group to minor and patch, so majors arrive individually.

First release through the version-driven pipeline: merging this tags v2.1.14, builds the release notes from the changelog section, and publishes.