### PR TITLE
fix(parser): keep cross-references in initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes per release. Older history is in the git log.
 
+## 2.1.15 - 2026-08-28
+
+### Fixed
+
+- Initializers that cross-reference another documented symbol keep the reference. `#define RETRY_HOOK registry->retry` rendered as `#define RETRY_HOOK ->retry`, because the initializer was read as flat text and every `<ref>` child was discarded. Reported by @gkodinov in #127.
+
+  Macros gained initializer rendering in 2.1.13, so they showed this from that release. Variable initializers were affected for longer, and are fixed by the same change.
+
 ## 2.1.14 - 2026-08-27
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moxygen",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moxygen",
-      "version": "2.1.14",
+      "version": "2.1.15",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moxygen",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Doxygen XML to Markdown converter",
   "type": "module",
   "main": "dist/index.js",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -613,8 +613,11 @@ function parseMember(
   member.isConsteval = attrs.consteval === 'yes';
   member.returnType = trim(toMarkdown(memberdef.type));
 
+  // Initializers can reference other documented symbols, so they go through
+  // the markdown conversion rather than being read as flat text. Reading `_`
+  // alone drops every <ref> child, turning `registry->retry` into `->retry`.
   if (memberdef.initializer) {
-    member.initializer = (memberdef.initializer as Array<Record<string, string>>)[0]?._ ?? '';
+    member.initializer = mdField(memberdef, 'initializer');
   }
 
   if (memberdef.location) {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -203,7 +203,9 @@ export function registerHelpers(options: Pick<MoxygenOptions, 'anchors' | 'htmlA
         .join(' ');
     }
     if (kind === 'variable') {
-      const init = member.initializer as string;
+      // Signatures render inside a code fence, where markdown links stay
+      // literal, so an initializer carrying refs is flattened to its text.
+      const init = stripMarkdownLinks(String(member.initializer ?? '')).trim();
       return init
         ? `${stripMarkdownLinks(member.returnType as string)} ${member.name} ${init}`
         : `${stripMarkdownLinks(member.returnType as string)} ${member.name}`;

--- a/test/fixtures/macros/src/macros.h
+++ b/test/fixtures/macros/src/macros.h
@@ -27,4 +27,17 @@
 */
 void reset(int);
 
+/**
+  Registry of handler hooks.
+*/
+struct handlers {
+  void (*retry)();
+} *registry;
+
+/**
+  Shorthand for the registry retry hook. Its initializer references another
+  documented symbol, so Doxygen emits a cross-reference inside the initializer.
+*/
+#define RETRY_HOOK registry->retry
+
 #endif /* __MACROS_H__ */

--- a/test/fixtures/macros/xml-out/xml/index.xml
+++ b/test/fixtures/macros/xml-out/xml/index.xml
@@ -1,10 +1,15 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <doxygenindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd" version="1.17.0" xml:lang="en-US">
+  <compound refid="structhandlers" kind="struct"><name>handlers</name>
+    <member refid="structhandlers_1a2edd8bed07fb12f754f9f167de9ed903" kind="variable"><name>retry</name></member>
+  </compound>
   <compound refid="macros_8h" kind="file"><name>macros.h</name>
     <member refid="macros_8h_1aecf13b8dc783db2202ca5c34fe117fc3" kind="define"><name>MAX_RETRIES</name></member>
     <member refid="macros_8h_1a318c6ec23f270a54557c2012c4dd0bce" kind="define"><name>CLAMP</name></member>
     <member refid="macros_8h_1a0bc63b24b654ca433be7b97a3edde132" kind="define"><name>UNREACHABLE</name></member>
     <member refid="macros_8h_1a920685f0ba8f8eebd13a8feb6ae286f6" kind="define"><name>UNDOCUMENTED_FLAG</name></member>
+    <member refid="macros_8h_1a1ee636c8ea8ef76556c00290eb5a289b" kind="define"><name>RETRY_HOOK</name></member>
+    <member refid="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" kind="variable"><name>registry</name></member>
     <member refid="macros_8h_1aa77e5763e57ffef3a8c0f08af40a73f8" kind="function"><name>reset</name></member>
   </compound>
   <compound refid="dir_68267d1309a1af8e8297ef4c3efbcdba" kind="dir"><name>src</name>

--- a/test/fixtures/macros/xml-out/xml/macros_8h.xml
+++ b/test/fixtures/macros/xml-out/xml/macros_8h.xml
@@ -2,6 +2,7 @@
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.17.0" xml:lang="en-US">
   <compounddef id="macros_8h" kind="file" language="C++">
     <compoundname>macros.h</compoundname>
+    <innerclass refid="structhandlers" prot="public">handlers</innerclass>
     <sectiondef kind="define">
       <memberdef kind="define" id="macros_8h_1aecf13b8dc783db2202ca5c34fe117fc3" prot="public" static="no">
         <name>MAX_RETRIES</name>
@@ -80,6 +81,33 @@
         </inbodydescription>
         <location file="src/macros.h" line="23" column="9" bodyfile="src/macros.h" bodystart="23" bodyend="-1"/>
       </memberdef>
+      <memberdef kind="define" id="macros_8h_1a1ee636c8ea8ef76556c00290eb5a289b" prot="public" static="no">
+        <name>RETRY_HOOK</name>
+        <initializer><ref refid="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" kindref="member">registry</ref>-&gt;retry</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+<para>Shorthand for the registry retry hook. Its initializer references another documented symbol, so Doxygen emits a cross-reference inside the initializer. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="src/macros.h" line="41" column="9" bodyfile="src/macros.h" bodystart="41" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="var">
+      <memberdef kind="variable" id="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" prot="public" static="no" mutable="no">
+        <type>struct <ref refid="structhandlers" kindref="compound">handlers</ref> *</type>
+        <definition>struct handlers * registry</definition>
+        <argsstring></argsstring>
+        <name>registry</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="src/macros.h" line="35" column="11"/>
+      </memberdef>
     </sectiondef>
     <sectiondef kind="func">
       <memberdef kind="function" id="macros_8h_1aa77e5763e57ffef3a8c0f08af40a73f8" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
@@ -118,7 +146,13 @@
 <codeline lineno="24"><highlight class="normal"></highlight></codeline>
 <codeline lineno="28" refid="macros_8h_1aa77e5763e57ffef3a8c0f08af40a73f8" refkind="member"><highlight class="normal"></highlight><highlight class="keywordtype">void</highlight><highlight class="normal"><sp/><ref refid="macros_8h_1aa77e5763e57ffef3a8c0f08af40a73f8" kindref="member">reset</ref>(</highlight><highlight class="keywordtype">int</highlight><highlight class="normal">);</highlight></codeline>
 <codeline lineno="29"><highlight class="normal"></highlight></codeline>
-<codeline lineno="30"><highlight class="normal"></highlight><highlight class="preprocessor">#endif<sp/></highlight><highlight class="comment">/*<sp/>__MACROS_H__<sp/>*/</highlight><highlight class="preprocessor"></highlight></codeline>
+<codeline lineno="33" refid="structhandlers" refkind="compound"><highlight class="normal"></highlight><highlight class="keyword">struct<sp/></highlight><highlight class="normal"><ref refid="structhandlers" kindref="compound">handlers</ref><sp/>{</highlight></codeline>
+<codeline lineno="34" refid="structhandlers_1a2edd8bed07fb12f754f9f167de9ed903" refkind="member"><highlight class="normal"><sp/><sp/>void<sp/>(*<ref refid="structhandlers_1a2edd8bed07fb12f754f9f167de9ed903" kindref="member">retry</ref>)();</highlight></codeline>
+<codeline lineno="35" refid="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" refkind="member"><highlight class="normal">}<sp/>*<ref refid="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" kindref="member">registry</ref>;</highlight></codeline>
+<codeline lineno="36"><highlight class="normal"></highlight></codeline>
+<codeline lineno="41" refid="macros_8h_1a1ee636c8ea8ef76556c00290eb5a289b" refkind="member"><highlight class="normal"></highlight><highlight class="preprocessor">#define<sp/>RETRY_HOOK<sp/>registry-&gt;retry</highlight><highlight class="normal"></highlight></codeline>
+<codeline lineno="42"><highlight class="normal"></highlight></codeline>
+<codeline lineno="43"><highlight class="normal"></highlight><highlight class="preprocessor">#endif<sp/></highlight><highlight class="comment">/*<sp/>__MACROS_H__<sp/>*/</highlight><highlight class="preprocessor"></highlight></codeline>
     </programlisting>
     <location file="src/macros.h"/>
   </compounddef>

--- a/test/fixtures/macros/xml-out/xml/structhandlers.xml
+++ b/test/fixtures/macros/xml-out/xml/structhandlers.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.17.0" xml:lang="en-US">
+  <compounddef id="structhandlers" kind="struct" language="C++" prot="public">
+    <compoundname>handlers</compoundname>
+    <includes refid="macros_8h" local="no">macros.h</includes>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="structhandlers_1a2edd8bed07fb12f754f9f167de9ed903" prot="public" static="no" mutable="no">
+        <type>void(*</type>
+        <definition>void(* handlers::retry) ()</definition>
+        <argsstring>)()</argsstring>
+        <name>retry</name>
+        <qualifiedname>handlers::retry</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="src/macros.h" line="34" column="3" bodyfile="src/macros.h" bodystart="34" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+<para>Registry of handler hooks. </para>
+    </detaileddescription>
+    <location file="src/macros.h" line="33" column="1" bodyfile="src/macros.h" bodystart="33" bodyend="35"/>
+    <listofallmembers>
+      <member refid="structhandlers_1a2edd8bed07fb12f754f9f167de9ed903" prot="public" virt="non-virtual"><scope>handlers</scope><name>retry</name></member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -561,5 +561,9 @@ describe('integration', () => {
 
     // Unnamed parameters keep their type.
     expect(api).toContain('void reset(int)');
+
+    // An initializer that cross-references another symbol keeps the reference
+    // as text. Reading the XML as flat text would leave "#define RETRY_HOOK ->retry".
+    expect(api).toContain('#define RETRY_HOOK registry->retry');
   });
 });

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -123,6 +123,28 @@ describe('template helpers', () => {
     expect(output).toBe('#define UNREACHABLE() __builtin_unreachable()');
   });
 
+  it('flattens cross-references in macro initializers', () => {
+    const output = renderSignature({
+      kind: 'define',
+      name: 'RETRY_HOOK',
+      initializer: '[registry](#registry)->retry',
+      params: [],
+    }).trim();
+
+    expect(output).toBe('#define RETRY_HOOK registry->retry');
+  });
+
+  it('flattens cross-references in variable initializers', () => {
+    const output = renderSignature({
+      kind: 'variable',
+      name: 'fallback',
+      returnType: 'handlers *',
+      initializer: '&[registry](#registry)',
+    }).trim();
+
+    expect(output).toBe('handlers * fallback &registry');
+  });
+
   it('renders typedefs as aliases instead of fake functions', () => {
     const output = renderSignature({
       kind: 'typedef',


### PR DESCRIPTION
Fixes #127, reported by @gkodinov.

`<initializer>` was read as flat text, so every `<ref>` child was discarded. `#define RETRY_HOOK registry->retry` came out as `#define RETRY_HOOK ->retry`. Initializers now go through the same markdown conversion as every other field.

Macros gained initializer rendering in 2.1.13, so they have shown this since then. Variable initializers were affected for longer and are fixed by the same change.

On the follow-up about linking the reference: signatures render inside a ```cpp fence, where `[baz](#baz)` stays literal rather than becoming a link. The HTML in the issue is Doxygen's own output, which has no such constraint. So the reference is flattened to its text here, which is what makes the fence read correctly.

Covered by a fixture case in `test/fixtures/macros` plus unit tests for both the macro and variable paths.

Bundles the 2.1.15 bump, so merging releases it.