### PR TITLE
fix(templates): keep cross-referenced types clickable in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes per release. Older history is in the git log.
 
+## 2.1.16 - 2026-08-28
+
+### Fixed
+
+- Parameter types that cross-reference another documented symbol rendered their link literally, as `` `struct [handlers](#handlers) *` ``, because a link cannot live inside a code span. Referenced types now keep the link and style the symbol the way names are styled elsewhere: `struct [`handlers`](#handlers) *`. Types with no reference are unchanged. Raised by @gkodinov in #127.
+- Return types in member summary tables link to the referenced symbol instead of being flattened to plain text.
+
 ## 2.1.15 - 2026-08-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moxygen",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moxygen",
-      "version": "2.1.15",
+      "version": "2.1.16",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moxygen",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "Doxygen XML to Markdown converter",
   "type": "module",
   "main": "dist/index.js",

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -17,6 +17,28 @@ const DEFAULT_RENDER_CONTEXT: RenderContext = {
   headingBase: 1,
 };
 
+const MARKDOWN_LINK = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+/**
+ * Render a type for a table cell.
+ *
+ * Types carry cross-references to other documented symbols. Wrapping the whole
+ * type in a code span turns those into literal `[name](href)` text, because a
+ * link cannot live inside a code span. So a type holding references keeps them
+ * as links, styling each reference the way names are styled elsewhere, and a
+ * plain type stays fully inline code.
+ */
+function typeCell(type: string): string {
+  const trimmed = (type || '').trim();
+  if (!trimmed) return '';
+
+  MARKDOWN_LINK.lastIndex = 0;
+  if (!MARKDOWN_LINK.test(trimmed)) return `\`${trimmed}\``;
+
+  MARKDOWN_LINK.lastIndex = 0;
+  return trimmed.replace(MARKDOWN_LINK, '[`$1`]($2)');
+}
+
 function headingLevel(relativeLevel: unknown, context: RenderContext): number {
   const relative = Number(relativeLevel);
   const base = Number.isFinite(context.headingBase) ? context.headingBase : 1;
@@ -349,10 +371,10 @@ export function registerHelpers(options: Pick<MoxygenOptions, 'anchors' | 'htmlA
   });
 
   // Return type for summary tables: strip markdown links to plain text
+  Handlebars.registerHelper('typeCell', (type: unknown) => typeCell(String(type ?? '')));
+
   Handlebars.registerHelper('returnTypeShort', function (this: Record<string, unknown>) {
-    const rt = (this.returnType as string) || '';
-    const clean = rt.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1').trim();
-    return clean ? `\`${clean}\`` : '';
+    return typeCell((this.returnType as string) || '');
   });
 
   // Linked name: renders as markdown link if refid exists

--- a/templates/cpp/class.md
+++ b/templates/cpp/class.md
@@ -118,7 +118,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/templates/cpp/index.md
+++ b/templates/cpp/index.md
@@ -73,7 +73,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/templates/cpp/namespace.md
+++ b/templates/cpp/namespace.md
@@ -105,7 +105,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/templates/java/class.md
+++ b/templates/java/class.md
@@ -55,7 +55,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/templates/java/index.md
+++ b/templates/java/index.md
@@ -73,7 +73,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/templates/java/namespace.md
+++ b/templates/java/namespace.md
@@ -105,7 +105,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| `{{name}}` | {{#if type}}`{{type}}`{{/if}} | {{description}} |
+{{#each (documentedParams params)}}| `{{name}}` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
 

--- a/test/fixtures/macros/src/macros.h
+++ b/test/fixtures/macros/src/macros.h
@@ -40,4 +40,13 @@ struct handlers {
 */
 #define RETRY_HOOK registry->retry
 
+/**
+  Configure a handler registry.
+
+  @param target the registry to configure
+  @param count how many retries to allow
+  @return the configured registry
+*/
+struct handlers *configure(struct handlers *target, int count);
+
 #endif /* __MACROS_H__ */

--- a/test/fixtures/macros/xml-out/xml/index.xml
+++ b/test/fixtures/macros/xml-out/xml/index.xml
@@ -11,6 +11,7 @@
     <member refid="macros_8h_1a1ee636c8ea8ef76556c00290eb5a289b" kind="define"><name>RETRY_HOOK</name></member>
     <member refid="macros_8h_1a37285142ae15ca3cdc36f3a03faeb0c9" kind="variable"><name>registry</name></member>
     <member refid="macros_8h_1aa77e5763e57ffef3a8c0f08af40a73f8" kind="function"><name>reset</name></member>
+    <member refid="macros_8h_1af6f5804d6181b428b0abd148e8005ff6" kind="function"><name>configure</name></member>
   </compound>
   <compound refid="dir_68267d1309a1af8e8297ef4c3efbcdba" kind="dir"><name>src</name>
   </compound>

--- a/test/fixtures/macros/xml-out/xml/macros_8h.xml
+++ b/test/fixtures/macros/xml-out/xml/macros_8h.xml
@@ -127,6 +127,48 @@
         </inbodydescription>
         <location file="src/macros.h" line="28" column="6" declfile="src/macros.h" declline="28" declcolumn="6"/>
       </memberdef>
+      <memberdef kind="function" id="macros_8h_1af6f5804d6181b428b0abd148e8005ff6" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>struct <ref refid="structhandlers" kindref="compound">handlers</ref> *</type>
+        <definition>struct handlers * configure</definition>
+        <argsstring>(struct handlers *target, int count)</argsstring>
+        <name>configure</name>
+        <param>
+          <type>struct <ref refid="structhandlers" kindref="compound">handlers</ref> *</type>
+          <declname>target</declname>
+        </param>
+        <param>
+          <type>int</type>
+          <declname>count</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+<para>Configure a handler registry.</para>
+<para><parameterlist kind="param"><parameteritem>
+<parameternamelist>
+<parametername>target</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the registry to configure </para>
+</parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername>count</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>how many retries to allow </para>
+</parameterdescription>
+</parameteritem>
+</parameterlist>
+<simplesect kind="return"><para>the configured registry </para>
+</simplesect>
+</para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="src/macros.h" line="50" column="15" declfile="src/macros.h" declline="50" declcolumn="15"/>
+      </memberdef>
     </sectiondef>
     <briefdescription>
     </briefdescription>
@@ -152,7 +194,9 @@
 <codeline lineno="36"><highlight class="normal"></highlight></codeline>
 <codeline lineno="41" refid="macros_8h_1a1ee636c8ea8ef76556c00290eb5a289b" refkind="member"><highlight class="normal"></highlight><highlight class="preprocessor">#define<sp/>RETRY_HOOK<sp/>registry-&gt;retry</highlight><highlight class="normal"></highlight></codeline>
 <codeline lineno="42"><highlight class="normal"></highlight></codeline>
-<codeline lineno="43"><highlight class="normal"></highlight><highlight class="preprocessor">#endif<sp/></highlight><highlight class="comment">/*<sp/>__MACROS_H__<sp/>*/</highlight><highlight class="preprocessor"></highlight></codeline>
+<codeline lineno="50" refid="macros_8h_1af6f5804d6181b428b0abd148e8005ff6" refkind="member"><highlight class="normal"></highlight><highlight class="keyword">struct<sp/></highlight><highlight class="normal"><ref refid="structhandlers" kindref="compound">handlers</ref><sp/>*<ref refid="macros_8h_1af6f5804d6181b428b0abd148e8005ff6" kindref="member">configure</ref>(</highlight><highlight class="keyword">struct</highlight><highlight class="normal"><sp/><ref refid="structhandlers" kindref="compound">handlers</ref><sp/>*target,<sp/></highlight><highlight class="keywordtype">int</highlight><highlight class="normal"><sp/>count);</highlight></codeline>
+<codeline lineno="51"><highlight class="normal"></highlight></codeline>
+<codeline lineno="52"><highlight class="normal"></highlight><highlight class="preprocessor">#endif<sp/></highlight><highlight class="comment">/*<sp/>__MACROS_H__<sp/>*/</highlight><highlight class="preprocessor"></highlight></codeline>
     </programlisting>
     <location file="src/macros.h"/>
   </compounddef>

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -565,5 +565,9 @@ describe('integration', () => {
     // An initializer that cross-references another symbol keeps the reference
     // as text. Reading the XML as flat text would leave "#define RETRY_HOOK ->retry".
     expect(api).toContain('#define RETRY_HOOK registry->retry');
+
+    // A parameter whose type is another documented symbol stays clickable.
+    // Wrapping the whole type in a code span would print the link literally.
+    expect(api).toContain('| `target` | struct [`handlers`](#handlers) * | the registry to configure |');
   });
 });

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -8,10 +8,10 @@ const renderParamTable = Handlebars.compile(`
 {{#if (hasDocumentedParams params)}}
 | Parameter | Type | Description |
 |-----------|------|-------------|
-{{#each (documentedParams params)}}| \`{{name}}\` | \`{{type}}\` | {{description}} |
+{{#each (documentedParams params)}}| \`{{name}}\` | {{typeCell type}} | {{description}} |
 {{/each}}
 {{/if}}
-`);
+`, { noEscape: true }); // matches how loadTemplates compiles the real templates
 
 const renderMemberSummary = Handlebars.compile(`{{memberSummary this}}`);
 const renderSignature = Handlebars.compile(`{{signature}}`, { noEscape: true });
@@ -40,6 +40,28 @@ describe('template helpers', () => {
     expect(output).toContain('| Parameter | Type | Description |');
     expect(output).toContain('| `mode` | `uv_run_mode` | libuv run mode. |');
     expect(output).not.toContain('| `loop` | `Loop *` |');
+  });
+
+  it('keeps cross-referenced types clickable in parameter tables', () => {
+    const output = renderParamTable({
+      params: [
+        { name: 'target', type: 'struct [handlers]({#ref structhandlers #}) *', description: 'the registry' },
+        { name: 'count', type: 'int', description: 'how many' },
+      ],
+    });
+
+    // A link cannot live inside a code span, so a referenced type keeps the
+    // link and styles the symbol the way names are styled elsewhere.
+    expect(output).toContain('| `target` | struct [`handlers`]({#ref structhandlers #}) * | the registry |');
+    expect(output).toContain('| `count` | `int` | how many |');
+  });
+
+  it('leaves the type cell empty for parameters with no type', () => {
+    const output = renderParamTable({
+      params: [{ name: 'VALUE', type: '', description: 'the value to clamp' }],
+    });
+
+    expect(output).toContain('| `VALUE` |  | the value to clamp |');
   });
 
   it('synthesizes deleted constructor summaries when documentation is missing', () => {


### PR DESCRIPTION
Follows up @gkodinov's point on #127, which turned out to be a rendering bug rather than only a missing feature.

A parameter whose type is another documented symbol was rendered as:

```
| `target` | `struct [handlers](#handlers) *` | the registry to configure |
```

A link cannot live inside a code span, so readers saw the raw link syntax. Referenced types now keep the link and style the symbol the way `linkedName` already styles names elsewhere:

```
| `target` | struct [`handlers`](#handlers) * | the registry to configure |
```

Types with no reference are untouched and stay fully inline code. Return types in member summary tables link too, via the same helper, so there is one behaviour rather than two.

`returnTypeShort` is kept and delegates to the new `typeCell` helper, so templates copied from `templates/cpp` keep working and pick up the fix.

Covered by a real fixture case (a documented struct used as a parameter and return type) plus unit tests. Also fixed the unit test harness, which compiled its local template without `noEscape` and so did not match how `loadTemplates` compiles the real ones.

Bundles the 2.1.16 bump.